### PR TITLE
refactor: standardize member invite link format to nomadcrew://invite…

### DIFF
--- a/handlers/trip_handler.go
+++ b/handlers/trip_handler.go
@@ -1007,13 +1007,11 @@ func (h *TripHandler) HandleInvitationDeepLink(c *gin.Context) {
 		strings.Contains(strings.ToLower(userAgent), "iphone") ||
 		strings.Contains(strings.ToLower(userAgent), "ipad")
 
+	// Use the new format for both mobile and web
 	var redirectURL string
-
 	if isMobile {
-		// For mobile devices, use the app scheme
-		// This should match what's configured in your Expo app
-		redirectURL = fmt.Sprintf("nomadcrew://invite/accept?token=%s&tripId=%s&email=%s",
-			token, claims.TripID, claims.InviteeEmail)
+		// For mobile devices, use the app scheme with the new format
+		redirectURL = fmt.Sprintf("nomadcrew://invite/accept/%s", token)
 	} else {
 		// For web browsers, redirect to the web frontend
 		redirectURL = fmt.Sprintf("%s/invite/accept/%s", frontendURL, token)

--- a/models/trip/command/invite_member.go
+++ b/models/trip/command/invite_member.go
@@ -86,30 +86,8 @@ func (c *InviteMemberCommand) Execute(ctx context.Context) (*interfaces.CommandR
 		return nil, err
 	}
 
-	// Build acceptance URL
-	frontendURL := c.Ctx.Config.FrontendURL
-
-	// Ensure frontendURL is not empty and has a protocol
-	if frontendURL == "" {
-		frontendURL = "https://nomadcrew.uk" // Default fallback
-		log := logger.GetLogger()
-		log.Warnw("FrontendURL not configured, using default", "default", frontendURL)
-	}
-
-	// Ensure URL has protocol
-	if !strings.HasPrefix(frontendURL, "http://") && !strings.HasPrefix(frontendURL, "https://") {
-		frontendURL = "https://" + frontendURL
-		log := logger.GetLogger()
-		log.Warnw("FrontendURL missing protocol, adding https://", "frontendURL", frontendURL)
-	}
-
-	// Remove trailing slash if present
-	frontendURL = strings.TrimSuffix(frontendURL, "/")
-
-	acceptanceURL := fmt.Sprintf("%s/invite/accept/%s",
-		frontendURL,
-		token,
-	)
+	// Build acceptance URL - use the new format
+	acceptanceURL := fmt.Sprintf("nomadcrew://invite/accept/%s", token)
 
 	log := logger.GetLogger()
 	log.Infow("Generated invitation acceptance URL",

--- a/services/email_service.go
+++ b/services/email_service.go
@@ -175,6 +175,11 @@ const invitationEmailTemplate = `<!DOCTYPE html>
             color: #777777;
             word-break: break-all;
         }
+        .note {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #777777;
+        }
     </style>
 </head>
 <body>
@@ -190,6 +195,10 @@ const invitationEmailTemplate = `<!DOCTYPE html>
         <p class="link">
             Or copy this link:<br/>
             {{.AcceptanceURL}}
+        </p>
+        <p class="note">
+            If you're on a mobile device, the link will open directly in the NomadCrew app.
+            On desktop, you'll be redirected to our website.
         </p>
     </div>
 </body>


### PR DESCRIPTION
refactor: standardize member invite link format to nomadcrew://invite/accept/{token}

- Update mobile deep link format to use path parameter instead of query params
- Keep web format unchanged (https://nomadcrew.uk/invite/accept/{token})
- Add mobile app note in invitation email template